### PR TITLE
Fix Altegio token env variable typo

### DIFF
--- a/services/altegio.service.js
+++ b/services/altegio.service.js
@@ -1,7 +1,9 @@
 import axios from 'axios'
 
-const partnerToken = process.env.ALTEGION_TOKEN
-const userToken = process.env.ALTEGION_USER_TOKEN
+// Допоміжне зчитування токенів: спершу шукаємо правильні ALTEGIO_*,
+// але підтримуємо й попереднє написання ALTEGION_* щоб не ламати оточення.
+const partnerToken = process.env.ALTEGIO_TOKEN ?? process.env.ALTEGION_TOKEN
+const userToken = process.env.ALTEGIO_USER_TOKEN ?? process.env.ALTEGION_USER_TOKEN
 
 export async function fetchProduct(companyId, productId) {
   try {


### PR DESCRIPTION
## Summary
- read Altegio tokens from correctly spelled ALTEGIO_* environment variables while keeping backwards compatibility with the previous typo

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69249b418cf88329963aaf2a79939fe5)