### PR TITLE
Add configuration validation and webhook hardening

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "ejs": "^3.1.10",
     "express": "^5.1.0",
     "graphql": "^16.11.0",
-    "graphql-request": "^7.2.0"
+    "graphql-request": "^7.2.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "dotenv": "^16.5.0",

--- a/services/altegio.service.js
+++ b/services/altegio.service.js
@@ -1,9 +1,5 @@
 import axios from 'axios'
-
-// Допоміжне зчитування токенів: спершу шукаємо правильні ALTEGIO_*,
-// але підтримуємо й попереднє написання ALTEGION_* щоб не ламати оточення.
-const partnerToken = process.env.ALTEGIO_TOKEN ?? process.env.ALTEGION_TOKEN
-const userToken = process.env.ALTEGIO_USER_TOKEN ?? process.env.ALTEGION_USER_TOKEN
+import { CONFIG } from '../utils/config.js'
 
 export async function fetchProduct(companyId, productId) {
   try {
@@ -11,7 +7,7 @@ export async function fetchProduct(companyId, productId) {
       `https://api.alteg.io/api/v1/goods/${companyId}/${productId}`,
       {
         headers: {
-          'Authorization': `Bearer ${partnerToken}, User ${userToken}`,
+          'Authorization': `Bearer ${CONFIG.altegio.partnerToken}, User ${CONFIG.altegio.userToken}`,
           Accept: 'application/vnd.api.v2+json'
         }
       }

--- a/services/queue2.service.js
+++ b/services/queue2.service.js
@@ -1,16 +1,47 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import * as AltegioService from '../services/altegio.service.js';
 import * as ShopifyService from '../services/shopify.service.js'
-import { useStore } from '../store/useStore.js';
 import { CacheManager } from '../store/cache.manager.js';
+import { CONFIG } from '../utils/config.js';
 
 const queueSet = new Set();
+const retryCounts = new Map();
 let isProcessing = false;
 
-const { getAltegioArticleById } = useStore()
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const QUEUE_FILE = path.join(__dirname, '..', 'store', 'pending-queue.json');
+
+function loadQueueFromDisk() {
+  try {
+    if (fs.existsSync(QUEUE_FILE)) {
+      const raw = fs.readFileSync(QUEUE_FILE, 'utf-8');
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        parsed.forEach(id => queueSet.add(id));
+      }
+    }
+  } catch (err) {
+    console.warn('⚠️ Unable to load queue from disk:', err.message);
+  }
+}
+
+function persistQueue() {
+  try {
+    fs.writeFileSync(QUEUE_FILE, JSON.stringify([...queueSet]));
+  } catch (err) {
+    console.warn('⚠️ Unable to persist queue:', err.message);
+  }
+}
+
+loadQueueFromDisk();
 
 export function addIdsToQueue(ids) {
   const idArray = Array.isArray(ids) ? ids : [ids]
   idArray.forEach(id => queueSet.add(id))
+  persistQueue();
 }
 
 export async function processNextId() {
@@ -20,31 +51,52 @@ export async function processNextId() {
   const iterator = queueSet.values();
   const goodId = iterator.next().value;
   queueSet.delete(goodId);
+  persistQueue();
 
   const ctx = {
     altegio_sku: '',
-    quantity: null
+    quantity: null,
+    storage_id: CONFIG.altegio.storageId,
   }
 
   try {
-    const altegioProduct = await AltegioService.fetchProduct(1275575, goodId)
-    ctx.altegio_sku = altegioProduct?.data?.article
-    ctx.quantity = altegioProduct.data.actual_amounts.find(a => a.storage_id === 2557508)?.amount;
-
-    const inventoryItemId = await CacheManager.inventoryItemIdByAltegioSku(ctx.altegio_sku)
-    if (!inventoryItemId) {
-      CacheManager.logWebhook({ status: 'skipped', reason: 'Inventory item id not found', type: 'correction', altegio_sku: ctx.altegio_sku, quantity: ctx.quantity });
-      isProcessing = false;
-      return
-    }
-    await ShopifyService.setAbsoluteQuantity(inventoryItemId, ctx.quantity)
-    CacheManager.logWebhook({ status: 'success', type: 'correction', altegio_sku: ctx.altegio_sku, quantity: ctx.quantity });
+    await handleGoodId(goodId, ctx);
+    retryCounts.delete(goodId);
   } catch (err) {
+    const nextAttempt = (retryCounts.get(goodId) ?? 0) + 1;
+    retryCounts.set(goodId, nextAttempt);
+
     CacheManager.logWebhook({ status: 'error', reason: err.message, type: 'correction', altegio_sku: ctx.altegio_sku, quantity: ctx.quantity });
     console.error('❌ Task failed:', err.message);
+
+    const delay = Math.min(30000, CONFIG.queue.backoffBaseMs * Math.pow(2, nextAttempt));
+    setTimeout(() => {
+      queueSet.add(goodId);
+      persistQueue();
+    }, delay);
   } finally {
     isProcessing = false;
   }
+}
+
+async function handleGoodId(goodId, ctx) {
+  const altegioProduct = await AltegioService.fetchProduct(CONFIG.altegio.companyId, goodId)
+  ctx.altegio_sku = altegioProduct?.data?.article
+
+  const amount = (altegioProduct?.data?.actual_amounts ?? []).find(a => a.storage_id === CONFIG.altegio.storageId)?.amount;
+  ctx.quantity = typeof amount === 'number' ? amount : null;
+
+  if (ctx.quantity === null) {
+    throw new Error(`Quantity missing for good ${goodId} and storage ${CONFIG.altegio.storageId}`);
+  }
+
+  const inventoryItemId = await CacheManager.inventoryItemIdByAltegioSku(ctx.altegio_sku)
+  if (!inventoryItemId) {
+    CacheManager.logWebhook({ status: 'skipped', reason: 'Inventory item id not found', type: 'correction', altegio_sku: ctx.altegio_sku, quantity: ctx.quantity });
+    return
+  }
+  await ShopifyService.setAbsoluteQuantity(inventoryItemId, ctx.quantity, { altegioSku: ctx.altegio_sku, goodId, storageId: CONFIG.altegio.storageId })
+  CacheManager.logWebhook({ status: 'success', type: 'correction', altegio_sku: ctx.altegio_sku, quantity: ctx.quantity });
 }
 
 setInterval(processNextId, 2000);

--- a/steps/enforce-idempotency.step.js
+++ b/steps/enforce-idempotency.step.js
@@ -1,0 +1,23 @@
+import { CacheManager } from '../store/cache.manager.js';
+import { CONFIG } from '../utils/config.js';
+import crypto from 'crypto';
+
+export function enforceIdempotencyStep(ctx) {
+  const candidateId = ctx.eventId || ctx.input.event_id || ctx.input.data?.event_id || ctx.input.data?.id || null;
+  const correlationId = candidateId ? String(candidateId) : crypto.randomUUID();
+
+  ctx.eventId = candidateId;
+  ctx.correlationId = correlationId;
+  ctx.log.correlation_id = correlationId;
+
+  if (!candidateId) return;
+
+  if (CacheManager.isDuplicateEvent(candidateId)) {
+    ctx.done = true;
+    ctx.log.status = 'skipped';
+    ctx.log.reason = `Duplicate webhook ${candidateId}`;
+    return;
+  }
+
+  CacheManager.rememberEvent(candidateId, CONFIG.webhook.idempotencyTtlMs);
+}

--- a/steps/get-product-ids.step.js
+++ b/steps/get-product-ids.step.js
@@ -1,6 +1,8 @@
+import { CONFIG } from '../utils/config.js';
+
 export function getProductIdsStep(ctx) {
   if (ctx.input.resource === 'record') {
-    ctx.state.product_ids = ctx.input.data.goods_transactions.filter(g => g.storage_id === 2557508).map(g => g.good_id)
+    ctx.state.product_ids = ctx.input.data.goods_transactions.filter(g => g.storage_id === CONFIG.altegio.storageId).map(g => g.good_id)
   } else {
     ctx.state.product_ids = [ctx.input.data.good.id]
   }

--- a/steps/validate-rules.step.js
+++ b/steps/validate-rules.step.js
@@ -1,3 +1,5 @@
+import { CONFIG } from '../utils/config.js';
+
 export function validateRulesStep(ctx) {
   if (!ctx.rule) {
     ctx.log.status = 'skipped'
@@ -35,9 +37,15 @@ export function validateRulesStep(ctx) {
     ctx.done = true
   }
 
-  if (!ctx.done && ctx.rule.onlyStorageId && ctx.rule.onlyStorageId !== ctx.input.data.storage.id) {
+  if (!ctx.done && ctx.rule.onlyStorageId && ctx.rule.onlyStorageId !== ctx.input.data.storage?.id) {
     ctx.log.status = 'skipped'
     ctx.log.reason = 'Skip by storageId'
+    ctx.done = true
+  }
+
+  if (!ctx.done && ctx.input.data.storage?.id && ctx.input.data.storage.id !== CONFIG.altegio.storageId) {
+    ctx.log.status = 'skipped'
+    ctx.log.reason = `Skip by unexpected storageId: ${ctx.input.data.storage.id}`
     ctx.done = true
   }
 }

--- a/steps/validate-webhook-payload.step.js
+++ b/steps/validate-webhook-payload.step.js
@@ -1,0 +1,70 @@
+import { z } from 'zod';
+import { CONFIG } from '../utils/config.js';
+
+const resourceSchema = z.enum([
+  'goods_operations_sale',
+  'goods_operations_receipt',
+  'goods_operations_stolen',
+  'goods_operations_move',
+  'record',
+]);
+
+const baseSchema = z.object({
+  id: z.union([z.string(), z.number()]).optional(),
+  resource: resourceSchema,
+  status: z.string(),
+  data: z.object({
+    type: z.string().optional(),
+    type_id: z.number().optional(),
+    paid_full: z.number().optional(),
+    storage: z.object({ id: z.number() }).optional(),
+    good: z.object({ id: z.number() }).optional(),
+    goods_transactions: z
+      .array(
+        z.object({
+          storage_id: z.number(),
+          good_id: z.number(),
+        })
+      )
+      .optional(),
+  }),
+});
+
+export function validateWebhookPayloadStep(ctx) {
+  const parsed = baseSchema.safeParse(ctx.input);
+  if (!parsed.success) {
+    ctx.error = true;
+    ctx.log.status = 'error';
+    ctx.log.reason = parsed.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join('; ');
+    return;
+  }
+
+  const payload = parsed.data;
+
+  if (payload.resource === 'record') {
+    if (!payload.data.goods_transactions || payload.data.goods_transactions.length === 0) {
+      ctx.error = true;
+      ctx.log.status = 'error';
+      ctx.log.reason = 'goods_transactions list is required for record resource';
+      return;
+    }
+  } else {
+    if (!payload.data.storage?.id) {
+      ctx.error = true;
+      ctx.log.status = 'error';
+      ctx.log.reason = 'storage.id is required';
+      return;
+    }
+    if (!payload.data.good?.id) {
+      ctx.error = true;
+      ctx.log.status = 'error';
+      ctx.log.reason = 'good.id is required';
+      return;
+    }
+  }
+
+  ctx.input = payload;
+  ctx.eventId = payload.id ?? payload.data?.id ?? null;
+  ctx.log.company_id = CONFIG.altegio.companyId;
+  ctx.log.storage_id = payload.data.storage?.id ?? null;
+}

--- a/utils/config.js
+++ b/utils/config.js
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  PORT: z.coerce.number().int().positive().optional(),
+  WARMUP_ON_START: z.string().optional(),
+
+  ALTEGIO_COMPANY_ID: z.coerce.number().int().positive(),
+  ALTEGIO_STORAGE_ID: z.coerce.number().int().positive(),
+  ALTEGIO_TOKEN: z.string().min(1),
+  ALTEGIO_USER_TOKEN: z.string().min(1),
+
+  SF_API_VERSION: z.string().min(1),
+  SF_DOMAIN: z.string().min(1),
+  SF_ADMIN_ACCESS_TOKEN: z.string().min(1),
+  SF_CONST_LOCATION_ID: z.string().min(1),
+
+  BASIC_AUTH_USER: z.string().optional(),
+  BASIC_AUTH_PASS: z.string().optional(),
+
+  IDEMPOTENCY_TTL_MS: z.coerce.number().int().positive().optional(),
+  QUEUE_BACKOFF_BASE_MS: z.coerce.number().int().positive().optional(),
+});
+
+const envWithFallbacks = {
+  ...process.env,
+  ALTEGIO_TOKEN: process.env.ALTEGIO_TOKEN ?? process.env.ALTEGION_TOKEN,
+  ALTEGIO_USER_TOKEN: process.env.ALTEGIO_USER_TOKEN ?? process.env.ALTEGION_USER_TOKEN,
+};
+
+const env = envSchema.parse(envWithFallbacks);
+
+export const CONFIG = {
+  server: {
+    port: env.PORT ?? 3000,
+    warmupOnStart: env.WARMUP_ON_START === 'true',
+  },
+  altegio: {
+    companyId: env.ALTEGIO_COMPANY_ID,
+    storageId: env.ALTEGIO_STORAGE_ID,
+    partnerToken: env.ALTEGIO_TOKEN,
+    userToken: env.ALTEGIO_USER_TOKEN,
+  },
+  shopify: {
+    apiVersion: env.SF_API_VERSION,
+    domain: env.SF_DOMAIN,
+    adminAccessToken: env.SF_ADMIN_ACCESS_TOKEN,
+    locationId: env.SF_CONST_LOCATION_ID,
+  },
+  webhook: {
+    idempotencyTtlMs: env.IDEMPOTENCY_TTL_MS ?? 5 * 60 * 1000,
+  },
+  queue: {
+    backoffBaseMs: env.QUEUE_BACKOFF_BASE_MS ?? 1500,
+  },
+};


### PR DESCRIPTION
## Summary
- move Altegio/Shopify constants into a validated configuration module loaded from the environment
- add webhook payload validation, idempotency checks, and structured correlation logging
- persist the correction queue to disk with backoff retries and stricter Shopify quantity handling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924a25af8e483298f4cbae6a0f387c0)