### PR TITLE
Add fallback support for Altegio ID env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ Server:
 - SKU_REFRESH_INTERVAL_MS (optional, int) – how often to refresh Shopify SKU cache; default 900000 (15 minutes). Set to 0 to disable.
 
 Altegio:
-- ALTEGIO_COMPANY_ID (required, int)
-- ALTEGIO_STORAGE_ID (required, int)
+- ALTEGIO_COMPANY_ID (required, int) – also accepts ALTEGION_COMPANY_ID as fallback
+- ALTEGIO_STORAGE_ID (required, int) – also accepts ALTEGION_STORAGE_ID as fallback
 - ALTEGIO_TOKEN (required, string) – partner token; also accepts ALTEGION_TOKEN as fallback
 - ALTEGIO_USER_TOKEN (required, string) – user token; also accepts ALTEGION_USER_TOKEN as fallback
 

--- a/utils/config.js
+++ b/utils/config.js
@@ -59,6 +59,8 @@ const envSchema = z.object({
 
 const envWithFallbacks = {
   ...process.env,
+  ALTEGIO_COMPANY_ID: process.env.ALTEGIO_COMPANY_ID ?? process.env.ALTEGION_COMPANY_ID,
+  ALTEGIO_STORAGE_ID: process.env.ALTEGIO_STORAGE_ID ?? process.env.ALTEGION_STORAGE_ID,
   ALTEGIO_TOKEN: process.env.ALTEGIO_TOKEN ?? process.env.ALTEGION_TOKEN,
   ALTEGIO_USER_TOKEN: process.env.ALTEGIO_USER_TOKEN ?? process.env.ALTEGION_USER_TOKEN,
 };


### PR DESCRIPTION
## Summary
- add fallbacks for Altegio company and storage IDs using legacy ALTEGION_* variables
- document the new fallbacks alongside existing Altegio environment variables

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924aa84f9448329ad3347a083265e57)