### PR TITLE
Handle missing Yarn files in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.yarn/cache
+.yarn/unplugged
+.yarn/build-state.yml
+.yarn/install-state.gz
+.pnp.*
+.env
+npm-debug.log*
+yarn-error.log*
+.DS_Store
+coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Railway deployment image for Altegio → Shopify sync service
+FROM node:20-alpine AS base
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Enable Corepack for Yarn Berry and install dependencies with a reproducible lockfile
+RUN corepack enable
+# Copy dependency manifests; wildcards avoid build failures if optional Yarn files are absent
+COPY package.json yarn.lock* .yarnrc.yml* .yarn/ ./
+RUN yarn install --immutable \
+  && yarn cache clean
+
+# Copy application source
+COPY . .
+
+# Default port used by the app (configurable via PORT env)
+EXPOSE 3000
+
+# Start the service
+CMD ["yarn", "start"]


### PR DESCRIPTION
## Summary
- use wildcard patterns when copying Yarn manifests to avoid build failures when some files are absent

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925e67925248329917b513c56f9dcc6)