### PR TITLE
Remove deprecated version key from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   redis:
     image: redis:7-alpine


### PR DESCRIPTION
## Summary
- remove the obsolete version attribute from docker-compose.yml to align with current Compose recommendations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925eeefb860832991930acc86604bfa)