### PR TITLE
Fix full sync pagination stop condition

### DIFF
--- a/services/full-sync.service.js
+++ b/services/full-sync.service.js
@@ -45,11 +45,12 @@ export async function collectGoodsForFullSync() {
 
   while (page <= MAX_PAGES) {
     const pagePayload = await fetchProductsPage(CONFIG.altegio.companyId, { page, count: PAGE_SIZE });
-    const goods = filterGoodsForStorage(extractGoodsArray(pagePayload), CONFIG.altegio.storageId);
+    const rawGoods = extractGoodsArray(pagePayload);
+    const goods = filterGoodsForStorage(rawGoods, CONFIG.altegio.storageId);
 
     goods.forEach((good) => uniqueIds.add(good.id));
 
-    if (goods.length < PAGE_SIZE) break;
+    if (rawGoods.length < PAGE_SIZE) break;
     page += 1;
   }
 


### PR DESCRIPTION
## Summary
- use the unfiltered page size when deciding to continue full sync pagination
- ensure all Altegio goods pages are scanned even if some pages lack matching storage items

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925f7d20b888329b0696abb36336f2c)